### PR TITLE
Change path of doc.json from public to storage local driver

### DIFF
--- a/src/Controllers/ScrambleSwaggerController.php
+++ b/src/Controllers/ScrambleSwaggerController.php
@@ -3,6 +3,7 @@
 namespace Waad\ScrambleSwagger\Controllers;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 use Waad\ScrambleSwagger\Commands\GenerateScrambleSwagger;
 
 class ScrambleSwaggerController
@@ -29,14 +30,12 @@ class ScrambleSwaggerController
             throw new \Exception('Failed to generate Swagger documentation');
         }
 
-        $filePath = public_path('scramble-swagger/doc.json');
-        if (! file_exists($filePath)) {
+        $jsonContent = Storage::disk('local')->get('doc.json');
+        if (empty($jsonContent)) {
             return [];
         }
 
-        $jsonContent = file_get_contents($filePath);
         $data = json_decode($jsonContent, true);
-
         if (empty($data)) {
             return [];
         }

--- a/src/scramble-swagger/.gitignore
+++ b/src/scramble-swagger/.gitignore
@@ -1,1 +1,0 @@
-doc.json

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -11,7 +11,7 @@ class WorkbenchServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        app()->usePublicPath(__DIR__.'/../public');
+        //
     }
 
     /**

--- a/workbench/app/config/scramble.php
+++ b/workbench/app/config/scramble.php
@@ -1,0 +1,111 @@
+<?php
+
+use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
+
+return [
+    /*
+     * Your API path. By default, all routes starting with this path will be added to the docs.
+     * If you need to change this behavior, you can add your custom routes resolver using `Scramble::routes()`.
+     */
+    'api_path' => 'api',
+
+    /*
+     * Your API domain. By default, app domain is used. This is also a part of the default API routes
+     * matcher, so when implementing your own, make sure you use this config if needed.
+     */
+    'api_domain' => null,
+
+    /*
+     * The path where your OpenAPI specification will be exported.
+     */
+    'export_path' => 'api.json',
+
+    'info' => [
+        /*
+         * API version.
+         */
+        'version' => env('API_VERSION', '0.0.1'),
+
+        /*
+         * Description rendered on the home page of the API documentation (`/docs/api`).
+         */
+        'description' => '',
+    ],
+
+    /*
+     * Customize Stoplight Elements UI
+     */
+    'ui' => [
+        /*
+         * Define the title of the documentation's website. App name is used when this config is `null`.
+         */
+        'title' => null,
+
+        /*
+         * Define the theme of the documentation. Available options are `light` and `dark`.
+         */
+        'theme' => 'light',
+
+        /*
+         * Hide the `Try It` feature. Enabled by default.
+         */
+        'hide_try_it' => false,
+
+        /*
+         * Hide the schemas in the Table of Contents. Enabled by default.
+         */
+        'hide_schemas' => false,
+
+        /*
+         * URL to an image that displays as a small square logo next to the title, above the table of contents.
+         */
+        'logo' => '',
+
+        /*
+         * Use to fetch the credential policy for the Try It feature. Options are: omit, include (default), and same-origin
+         */
+        'try_it_credentials_policy' => 'include',
+
+        /*
+         * There are three layouts for Elements:
+         * - sidebar - (Elements default) Three-column design with a sidebar that can be resized.
+         * - responsive - Like sidebar, except at small screen sizes it collapses the sidebar into a drawer that can be toggled open.
+         * - stacked - Everything in a single column, making integrations with existing websites that have their own sidebar or other columns already.
+         */
+        'layout' => 'responsive',
+    ],
+
+    /*
+     * The list of servers of the API. By default, when `null`, server URL will be created from
+     * `scramble.api_path` and `scramble.api_domain` config variables. When providing an array, you
+     * will need to specify the local server URL manually (if needed).
+     *
+     * Example of non-default config (final URLs are generated using Laravel `url` helper):
+     *
+     * ```php
+     * 'servers' => [
+     *     'Live' => 'api',
+     *     'Prod' => 'https://scramble.dedoc.co/api',
+     * ],
+     * ```
+     */
+    'servers' => null,
+
+    /**
+     * Determines how Scramble stores the descriptions of enum cases.
+     * Available options:
+     * - 'description' – Case descriptions are stored as the enum schema's description using table formatting.
+     * - 'extension' – Case descriptions are stored in the `x-enumDescriptions` enum schema extension.
+     *
+     *    @see https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-enum-descriptions
+     * - false - Case descriptions are ignored.
+     */
+    'enum_cases_description_strategy' => 'description',
+
+    'middleware' => [
+        'web',
+        RestrictedDocsAccess::class,
+    ],
+
+    'extensions' => [],
+];

--- a/workbench/app/public/scramble-swagger/.gitignore
+++ b/workbench/app/public/scramble-swagger/.gitignore
@@ -1,2 +1,0 @@
-*.*
-!.gitignore


### PR DESCRIPTION
Refactor GenerateScrambleSwagger command to use local storage for JSON file handling and update ScrambleSwaggerController to retrieve JSON from local storage. Remove .gitignore for doc.json and clean up unused public directories.